### PR TITLE
cm: Remove root access prop

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -308,9 +308,6 @@ PRODUCT_PACKAGES += \
 endif
 endif
 
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.sys.root_access=1
-
 DEVICE_PACKAGE_OVERLAYS += vendor/cm/overlay/common
 
 PRODUCT_VERSION = 5.8.3


### PR DESCRIPTION
This property is already defaulted to 0 in the code.
The su_daemon is also disabled by default.

Thus, for all intents and purposes, root access is
already being disabled by default.

Change-Id: I1241689c0d3253aa2e44835c55839f24b3b74341